### PR TITLE
Add retry to lower energies acceptance

### DIFF
--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -19,7 +19,7 @@ struct WholeMoonRegion <: Region end
 struct CircularRegion <: Region
     center_lat::Float64
     center_lon::Float64
-    radius::Float64
+    radius::typeof(1.0km)
 end
 
 @with_kw struct PolarRegion <: Region
@@ -74,7 +74,7 @@ end
 
 function is_in_region(surface, region::CircularRegion)
     lat, lon = deg2rad.(cartesian_to_latlon(surface))
-    center_lat, center_lon = deg2rad.(region.center_lat, region.center_lon)
+    center_lat, center_lon = deg2rad.([region.center_lat, region.center_lon])
     
     dlat = (lat - center_lat)
     dlon = (lon - center_lon)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -233,7 +233,7 @@ function propagate_cosmicray(Ecr, surface, SC, trigger;
 
     # if it's an upgoing cosmic ray, reject the trial
     if surface ⋅ direction > 0km
-        println("Got an upgoing cosmic ray trial! This should never happen.")
+        @debug "Got an upgoing cosmic ray trial! This should never happen."
         return Upgoing, Upgoing
     end
 

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -18,7 +18,7 @@ This is characterized by Gaussian "sigma" of the
 angular distribution of the surface.
 """
 struct GaussianRoughness <: RoughnessModel
-    σ # in radians
+    σ::Float64 # in radians
     GaussianRoughness(σ) = new(deg2rad(σ))
 end
 
@@ -39,7 +39,7 @@ This is characterized by Gaussian "sigma" of the
 angular distribution of the surface in degrees.
 """
 struct GaussianSlope <: SlopeModel
-    σ # in radians
+    σ::Float64 # in radians
     GaussianSlope(σ) = new(deg2rad(σ))
 end
 


### PR DESCRIPTION
Allows user to increase sample size in `acceptance()` to some threshold using new arguments:


- `min_count `: attempts to get at least this many triggered direct events. After running ntrials, retry and do an additional ntrials runs (default=0, so no retries in the default case)
- `max_retries`: the maximum number of times to try ntrials. Gives up if `min_count` is still not reached after max_retries * ntrials events (default=10, so as soon as min_count is >0, allows up to 10x ntrials in the worst case)


Ex: `A = acceptance(ntrials=100, nbins=10, min_count=5, max_retries=7)`

- Run 100 trials in each of the 10 bins
- if 5 direct events are not triggered in a particular energy bin, run an additional 100 trials
  - repeat ntrials for this bin up to 7 times for a maximum total of 700 trials if min_count is not reached

The final acceptance is weighted by the appropriate number of trials and the final number of `retries` for each energy bin is returned in the `Acceptance` struct. To find the total number of events run for each energy, do `A.ntrials .* A.retries` where A is the output struct