### PR TITLE
WIP: Add carlo.jl method of running simulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /Manifest.toml
 /docs/build/
 /tmp
+/experiments
 .vscode
 .DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["C. J. Tai Udovicic <cjtu@hawaii.edu>", "R. Prechelt <prechelt@hawaii
 version = "0.2.1"
 
 [deps]
+Carlo = "780c37f4-4e5a-43de-9e79-65c261e525a4"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -24,6 +26,8 @@ ToggleableAsserts = "07ecc579-1b30-493c-b961-3180daf6e3ae"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+Carlo = "0.2.3"
+HDF5 = "0.17.2"
 julia = "1"
 
 [extras]

--- a/src/CoRaLS.jl
+++ b/src/CoRaLS.jl
@@ -7,8 +7,8 @@ using Unitful: g, cm, m, km, sr, μV, V, eV, GeV, EeV, Hz, MHz, W, K, NoUnits
 
 # exports from geometry.jl
 export Rmoon, random_point_on_cap, horizon_angle, random_direction, spherical_cap_area, random_point_on_sphere
-export WholeMoonRegion, CircularRegion, PolarRegion, CustomRegion, SouthPolePSR, NorthPolePSR, AllPSR, create_region, is_in_region, region_area, parse_orbit
-export FixedPlatform, CircularOrbit, SampledPositions, create_spacecraft, get_position
+export Region, WholeMoonRegion, CircularRegion, PolarRegion, CustomRegion, SouthPolePSR, NorthPolePSR, AllPSR, create_region, is_in_region, region_area, parse_orbit
+export Spacecraft, FixedPlatform, CircularOrbit, SampledPositions, create_spacecraft, get_position
 
 # exports from spectrum.jl
 export auger_spectrum_2021, auger_spectrum_2020, auger_spectrum, sample_auger, yr, cr_spectrum
@@ -45,13 +45,16 @@ export LPDA, ANITA
 export throw_cosmicray, ScalarGeometry, RaytracedGeometry, VectorGeometry
 
 # exports from trigger.jl
-export magnitude_trigger, gaussian_trigger, rician_trigger, trigger_all
+export magnitude_trigger, gaussian_trigger, rician_trigger, trigger_all, trigger_received
 
 # exports from moon.jl
 export psr_area, psr_fraction
 
 # exports from acceptance.jl
 export acceptance, differential_spectrum, trials_passed, old_acceptance, save_acceptance, load_acceptance, merge_acceptance
+
+# exports from acceptance_carlo.jl
+export MC
 
 # exports from plots.jl
 export plot_differential_spectrum, plot_incident_angles, plot_polarization_angle, plot_offaxis_angle, plot_acceptance
@@ -73,6 +76,7 @@ include("raytrace.jl")
 include("simulate.jl")
 include("detector.jl")
 include("acceptance.jl")
+include("acceptance_carlo.jl")
 include("surface.jl")
 include("plots.jl")
 

--- a/src/acceptance.jl
+++ b/src/acceptance.jl
@@ -71,7 +71,7 @@ function acceptance(ntrials::Int, nbins::Int;
             # loop over the number of trials in this bin
             for i = 1:ntrials
                 # throw a random cosmic ray trial and get the signal at the payload
-                direct, reflected = throw_cosmicray(sample_auger(energies[bin], energies[bin+1]), trigger, region, spacecraft; kwargs...)
+                direct, reflected = throw_cosmicray(sample_auger(energies[bin], energies[bin+1]), region, spacecraft; kwargs...)
                 if direct isa TrialFailed
                     dfailed[bin, Int(direct)] += 1
                 else

--- a/src/acceptance_carlo.jl
+++ b/src/acceptance_carlo.jl
@@ -1,0 +1,79 @@
+using Unitful: EeV, sr, ustrip
+using Carlo
+using HDF5
+
+"""
+Input parameters for the Monte Carlo acceptance calculation.
+"""
+mutable struct MC <: AbstractMC
+    energy::typeof(1.0EeV)
+    dcount::Int
+    rcount::Int
+    region::Region
+    spacecraft::Spacecraft
+    trigger
+    kwargs::AbstractDict
+end
+
+"""
+Constructor for MC. Runs on initial and restarted runs.
+"""
+function MC(params::AbstractDict)
+    energy = params[:energy]  * EeV
+    region = create_region(params[:region])
+    sc = create_spacecraft(params[:spacecraft])
+    trigger =  trigger_received()  #create_trigger(get(params, :trigger))
+    kwargs = get(params, :kwargs, Dict())  # Simulation params
+    return MC(energy, 0, 0, region, sc, trigger, kwargs)
+end
+
+"""
+Initialize a Carlo run. Runs only at the start of a run (not on restarts).
+"""
+function Carlo.init!(mc::MC, ctx::MCContext, params::AbstractDict)
+    # mc.dcount = 0
+    # mc.rcount = 0
+    return nothing
+end
+
+"""
+Main Monte Carlo loop. Pass all params to simulation and keep track of triggers.
+"""
+function Carlo.sweep!(mc::MC, ctx::MCContext)
+    direct, reflected = throw_cosmicray(mc.energy, mc.region, mc.spacecraft; mc.kwargs...)
+    mc.dcount += mc.trigger(direct)
+    mc.rcount += mc.trigger(reflected)
+    return nothing
+end
+
+"""
+Compute measured quantities with Carlo. Keeps track of error propagation.
+"""
+function Carlo.measure!(mc::MC , ctx::MCContext)
+    ntrials = ctx.sweeps
+    gAΩ = ustrip(pi * sr * region_area(WholeMoonRegion()))  # [km^2 sr]
+    dAΩ = gAΩ * (mc.dcount / ntrials)  
+    rAΩ = gAΩ * (mc.rcount / ntrials)
+
+    measure!(ctx, :dAΩ, dAΩ)
+    measure!(ctx, :rAΩ, rAΩ)
+
+    return nothing
+end
+
+# TODO: Figure out how to make final spectrum of events a carlo evaluable (w/ error propagation)
+function Carlo.register_evaluables(::Type{MC}, eval::AbstractEvaluator, params::AbstractDict)
+    return nothing
+end
+
+function Carlo.write_checkpoint(mc::MC, out::HDF5.Group)
+    out["dcount"] = mc.dcount
+    out["rcount"] = mc.rcount
+    return nothing
+end
+
+function Carlo.read_checkpoint!(mc::MC, in::HDF5.Group)
+    mc.dcount = read(in, "dcount")
+    mc.rcount = read(in, "rcount")
+    return nothing
+end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -142,7 +142,7 @@ Simulate a single cosmic ray trial with a given energy.
 This calculates the field at the payload for the direct and reflected emission,
 (if they exist) and returns whether the event triggered.
 """
-function throw_cosmicray(Ecr, trigger, region, spacecraft; kwargs...)
+function throw_cosmicray(Ecr, region, spacecraft; kwargs...)
     surface = random_point_on_sphere(Rmoon)
     SC = get_position(spacecraft)
     if !is_visible(surface, SC)
@@ -150,7 +150,7 @@ function throw_cosmicray(Ecr, trigger, region, spacecraft; kwargs...)
     elseif !is_in_region(surface, region)
         return (NotInRegion, NotInRegion)
     end
-    return propagate_cosmicray(Ecr, surface, SC, trigger; kwargs...)
+    return propagate_cosmicray(Ecr, surface, SC; kwargs...)
 end
 
 
@@ -160,7 +160,7 @@ Simulate a single cosmic ray trial with a given energy.
 This calculates the field at the payload for the direct and reflected emission,
 (if they exist) and returns whether the event triggered.
 """
-function throw_cosmicray(Ecr, trigger; altitude=20.0km, kwargs...)
+function throw_cosmicray(Ecr; altitude=20.0km, kwargs...)
 
     # get the maximum angle that we sample CR impact points from
     θmax = -horizon_angle(altitude)
@@ -212,13 +212,13 @@ function throw_cosmicray(Ecr, trigger; altitude=20.0km, kwargs...)
     # if this point is not within the horizon of the SC, then we can't see it.
     # abs(θ - θsc) > θmax && return (NotVisible, NotVisible)
     abs(Δσ) > θmax && return (NotVisible, NotVisible)
-    return propagate_cosmicray(Ecr, surface, SC, trigger; kwargs...)
+    return propagate_cosmicray(Ecr, surface, SC; kwargs...)
 end
 
 """
 Propagate cosmic ray into surface and compute direct and reflected RF.
 """
-function propagate_cosmicray(Ecr, surface, SC, trigger;
+function propagate_cosmicray(Ecr, surface, SC;
     ice_depth=5m,
     geometrymodel=ScalarGeometry(),
     indexmodel=StrangwayIndex(), fieldmodel=ARW(),

--- a/src/trigger.jl
+++ b/src/trigger.jl
@@ -122,8 +122,17 @@ end
 """
     trigger_all()
 
-Always triggers. Used for testing geometric acceptance and debugging.
+Always triggers. Used for testing and debugging.
 """
 function trigger_all()
     return event -> true
+end
+
+"""
+    trigger_received()
+
+Always triggers. Used for testing geometric acceptance and debugging.
+"""
+function trigger_received()
+    return event -> !isa(event, TrialFailed)
 end


### PR DESCRIPTION
Work in Progress (don't merge)

- Adding Carlo.jl to manage monte carlo integration, parallelism, error propagation
- removed redundant trigger param

Needs:
- tests
- worked example of how to use Carlo in the docs
- add DataFrame dependency for carlo outputs?
- propagate rng state for reproducibility
- add `create_trigger()` helper to convert string into trigger for easier param specification